### PR TITLE
Fix #113: Prevent terminal height shrink on click

### DIFF
--- a/src/components/Hero/Hero.css
+++ b/src/components/Hero/Hero.css
@@ -180,7 +180,7 @@
 .hero-terminal-hint.no-transition {
   transition: none;
   animation: none;
-  display: none;
+  visibility: hidden;
 }
 
 .hero-hint-key {


### PR DESCRIPTION
## Summary
- Changed `display: none` to `visibility: hidden` on `.hero-terminal-hint.no-transition` so the hint bar stays in the layout when the animation is skipped, preventing the terminal from shrinking in height.

## Test plan
- [ ] Click the hero terminal to skip animation — terminal height should stay the same
- [ ] Verify hint text becomes invisible but space is preserved
- [ ] Test on mobile (tap to skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)