### PR TITLE
Fix #120: Add correct videos to SignTalker project

### DIFF
--- a/src/pages/ProjectDetail/ProjectDetail.js
+++ b/src/pages/ProjectDetail/ProjectDetail.js
@@ -339,9 +339,9 @@ function ProjectDetail() {
       thesis: 'https://www.diva-portal.org/smash/get/diva2:1880636/FULLTEXT01.pdf',
       image: null,
       demoVideos: [
-        { title: 'Presentation', description: 'Introduktion till projektet och hur appen fungerar', url: 'https://www.youtube.com/embed/RrvsNtiPFXo' },
-        { title: 'Drive in', description: 'Beställer mat på McDonald\'s med hjälp av klockan', url: 'https://www.youtube.com/embed/RrvsNtiPFXo' },
-        { title: 'Dog mode', description: 'Ropar på sin hund med ett egentränat tecken kopplat till en inspelning av ägarens röst', url: 'https://www.youtube.com/embed/RrvsNtiPFXo' },
+        { title: 'Presentation', description: 'Introduktion till projektet och hur appen fungerar', url: 'https://www.youtube.com/embed/qRDOVvyBVKQ' },
+        { title: 'Drive in', description: 'Beställer mat på McDonald\'s med hjälp av klockan', url: 'https://www.youtube.com/embed/UfcuVqfH8x8' },
+        { title: 'Dog mode', description: 'Ropar på sin hund med ett egentränat tecken kopplat till en inspelning av ägarens röst', url: 'https://www.youtube.com/embed/-NRR78CkO18' },
       ],
       resultText: 'Användaren startar inspelningen från telefonen, som skickar en signal till klockan att börja läsa av rörelsesensorerna. Utöver vanliga tecken kan man även koppla egna handtecken till inspelningar av sin egen röst.',
       techDetails: [


### PR DESCRIPTION
## Summary
- Updated all three SignTalker demo videos with their correct unique YouTube URLs (previously all pointed to the same video)

## Test plan
- [ ] Verify each video plays the correct content on the SignTalker project page
- [ ] Presentation, Drive in, and Dog mode should all show different videos

🤖 Generated with [Claude Code](https://claude.com/claude-code)