### PR TITLE
Fix #110: Center logo based on inner text bounds

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -92,6 +92,7 @@
   flex-direction: column;
   align-items: center;
   gap: 0;
+  transform: translateX(-50px);
 }
 
 .header-title h1 {
@@ -312,6 +313,10 @@
   .header-center {
     flex: 1;
     justify-content: center;
+  }
+
+  .header-title {
+    transform: translateX(-20px);
   }
 
   .name-first {


### PR DESCRIPTION
## Summary
- Added `translateX` offset to `.header-title` to compensate for the asymmetric `margin-left` on "Engineer"
- Desktop: `-50px` offset (half of 100px margin)
- Mobile: `-20px` offset (half of 40px margin)
- The visual midpoint between "E" in Engineer and "N" in Carlsson now aligns with viewport center

## Test plan
- [ ] Verify logo appears visually centered on desktop
- [ ] Verify logo appears visually centered on mobile
- [ ] Check at intermediate screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)