### PR TITLE
Fix #125: Add tap to skip animation on CV page

### DIFF
--- a/src/pages/CV/CV.css
+++ b/src/pages/CV/CV.css
@@ -171,6 +171,20 @@
   background: rgba(255, 255, 255, 0.05);
 }
 
+.cv-hint-mobile {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .cv-hint-desktop {
+    display: none;
+  }
+
+  .cv-hint-mobile {
+    display: inline;
+  }
+}
+
 @keyframes cvSkipPulse {
   0%, 100% { opacity: 0.5; }
   50% { opacity: 0.3; }

--- a/src/pages/CV/CV.js
+++ b/src/pages/CV/CV.js
@@ -161,7 +161,7 @@ function CV() {
   });
 
   return (
-    <section className="cv-page">
+    <section className="cv-page" onClick={() => !queryComplete && skipAnimation()}>
       <div className="cv-particles">{particles}</div>
 
       <div className="cv-layout">
@@ -191,7 +191,8 @@ function CV() {
 
           {!queryComplete && (
             <div className="cv-skip-hint">
-              Tryck <span className="cv-skip-key">Enter</span> för att hoppa över
+              <span className="cv-hint-desktop">Tryck <span className="cv-skip-key">Enter</span> för att hoppa över</span>
+              <span className="cv-hint-mobile">Tryck för att hoppa över</span>
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- Added click/tap handler on the CV page section to skip the SQL animation
- Separate hint text: "Tryck Enter" on desktop, "Tryck" on mobile
- Responsive CSS to show/hide the correct hint at 768px breakpoint

## Test plan
- [ ] Desktop: pressing Enter skips animation (unchanged)
- [ ] Mobile: tapping anywhere on the page skips animation
- [ ] Hint text shows "Tryck Enter" on desktop, "Tryck" on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)